### PR TITLE
Fix null-safe equality in questions and remove Lombok

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,10 +38,8 @@ dependencies {
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 
 //	implementation("com.google.code.gson:gson:2.10.1")
-	compileOnly("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 //	developmentOnly("org.springframework.boot:spring-boot-docker-compose")
-	annotationProcessor("org.projectlombok:lombok")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/java/com/vdv/NExTone/exception/ErrorResponse.java
+++ b/src/main/java/com/vdv/NExTone/exception/ErrorResponse.java
@@ -1,13 +1,8 @@
 package com.vdv.NExTone.exception;
 
-import lombok.Getter;
-import lombok.Setter;
-
 import java.time.LocalDate;
 import java.util.List;
 
-@Getter
-@Setter
 public class ErrorResponse {
     private final LocalDate timestamp;
     private final Integer status;
@@ -17,13 +12,21 @@ public class ErrorResponse {
     private String path;
     private List<ValidationError> errors;
 
-    @Getter
     public static class ValidationError {
         private final String field;
         private final String message;
+
         public ValidationError(String field, String message) {
             this.field = field;
             this.message = message;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public String getMessage() {
+            return message;
         }
     }
 
@@ -37,6 +40,43 @@ public class ErrorResponse {
         this.message = message;
     }
 
+    public LocalDate getTimestamp() {
+        return timestamp;
+    }
 
+    public Integer getStatus() {
+        return status;
+    }
 
+    public String getError() {
+        return error;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public List<ValidationError> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<ValidationError> errors) {
+        this.errors = errors;
+    }
 }

--- a/src/main/java/com/vdv/NExTone/questionbank/model/Option.java
+++ b/src/main/java/com/vdv/NExTone/questionbank/model/Option.java
@@ -38,7 +38,7 @@ public class Option {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Option option1 = (Option) o;
-        return id.equals(option1.id) && option.equals(option1.option) && Objects.equals(comment, option1.comment);
+        return Objects.equals(id, option1.id) && Objects.equals(option, option1.option) && Objects.equals(comment, option1.comment);
     }
 
     @Override

--- a/src/main/java/com/vdv/NExTone/questionbank/model/Question.java
+++ b/src/main/java/com/vdv/NExTone/questionbank/model/Question.java
@@ -18,7 +18,7 @@ public record Question(
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Question question = (Question) o;
-        return id.equals(question.id) && questionNumber.equals(question.questionNumber);
+        return Objects.equals(id, question.id) && Objects.equals(questionNumber, question.questionNumber);
     }
 
     @Override

--- a/src/test/java/com/vdv/NExTone/questionbank/model/OptionTest.java
+++ b/src/test/java/com/vdv/NExTone/questionbank/model/OptionTest.java
@@ -1,0 +1,16 @@
+package com.vdv.NExTone.questionbank.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OptionTest {
+
+    @Test
+    void equalsHandlesNullIds() {
+        Option o1 = new Option(null, "A");
+        Option o2 = new Option(null, "A");
+        assertDoesNotThrow(() -> o1.equals(o2));
+        assertEquals(o1, o2);
+    }
+}

--- a/src/test/java/com/vdv/NExTone/questionbank/model/QuestionTest.java
+++ b/src/test/java/com/vdv/NExTone/questionbank/model/QuestionTest.java
@@ -1,0 +1,25 @@
+package com.vdv.NExTone.questionbank.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuestionTest {
+
+    @Test
+    void equalsHandlesNullIds() {
+        Question q1 = new Question(null, 1, "question", List.of(), null);
+        Question q2 = new Question(null, 1, "question", List.of(), null);
+        assertDoesNotThrow(() -> q1.equals(q2));
+        assertEquals(q1, q2);
+    }
+
+    @Test
+    void notEqualsWhenQuestionNumberDiffers() {
+        Question q1 = new Question(null, 1, "question", List.of(), null);
+        Question q2 = new Question(null, 2, "question", List.of(), null);
+        assertNotEquals(q1, q2);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid NullPointerException in Question and Option equality checks
- drop Lombok and implement explicit accessors for ErrorResponse
- add tests for Question and Option equality

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies, received 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_688df1e364b48326bcb175c80227f20a